### PR TITLE
Added logic to share metrics/information from the interceptor to the app

### DIFF
--- a/example/src/oklog3/java/com/github/simonpercic/oklogexample/data/api/ApiServiceProvider.java
+++ b/example/src/oklog3/java/com/github/simonpercic/oklogexample/data/api/ApiServiceProvider.java
@@ -1,7 +1,9 @@
 package com.github.simonpercic.oklogexample.data.api;
 
 import android.support.annotation.NonNull;
+import android.util.Log;
 
+import com.github.simonpercic.oklog3.APIMetrics;
 import com.github.simonpercic.oklog3.OkLogInterceptor;
 import com.github.simonpercic.oklogexample.Constants;
 
@@ -30,7 +32,19 @@ public final class ApiServiceProvider {
      * @return ApiService
      */
     @NonNull public static ApiService createApiService() {
-        OkLogInterceptor okLogInterceptor = OkLogInterceptor.builder().build();
+
+        APIMetrics metrics =  new APIMetrics() {
+            @Override
+            public void onCaptureResponseTime(long responseTime) {
+                //Do Anything with the response time.
+                //Push to Google Analytics/Fabric
+                Log.d("Response Time", String.valueOf(responseTime));
+            }
+        };
+
+        OkLogInterceptor okLogInterceptor = OkLogInterceptor.builder()
+                .withAPIMetrics(metrics)
+                .build();
 
         HttpLoggingInterceptor httpLoggingInterceptor = createHttpLoggingInterceptor();
 

--- a/oklog3/src/main/java/com/github/simonpercic/oklog3/APIMetrics.java
+++ b/oklog3/src/main/java/com/github/simonpercic/oklog3/APIMetrics.java
@@ -1,0 +1,12 @@
+package com.github.simonpercic.oklog3;
+
+/**
+ * @hannanshaik <a href="https://github.com/hannanshaik">https://github.com/hannanshaik</a>
+ */
+
+/**
+ * To capture any kind of metrics during or after the API call.
+ */
+public abstract class APIMetrics {
+    public abstract void onCaptureResponseTime(long timeTaken);
+}


### PR DESCRIPTION
I had a requirement to publish the response time for APIs to Analytics engine (Fabric Answers). This change in the codebase enables it. 

Do merge, if you think this would be useful for others.