### PR TITLE
Removed dependency on Android Base64 encoding with Okio

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -20,8 +20,6 @@ android {
         targetSdkVersion project.ext.targetSdkVersion
         versionCode Integer.parseInt(VERSION_CODE)
         versionName VERSION_NAME
-
-        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
 
     lintOptions {
@@ -51,10 +49,6 @@ dependencies {
     testCompile "org.mockito:mockito-core:$mockitoVersion"
     testCompile "org.powermock:powermock-module-junit4:$powermockVersion"
     testCompile "org.powermock:powermock-api-mockito:$powermockVersion"
-
-    // Android test dependencies
-    androidTestCompile "com.android.support.test:runner:$testSupportVersion"
-    androidTestCompile "com.android.support.test:rules:$testSupportVersion"
 
     // Static code rules
     checkstyleRules files('../config/soter/checkstyle-0.3.xml')

--- a/core/src/androidTest/java/com/github/simonpercic/oklog/core/CompressionUtilsTest.java
+++ b/core/src/androidTest/java/com/github/simonpercic/oklog/core/CompressionUtilsTest.java
@@ -13,10 +13,13 @@ public class CompressionUtilsTest {
 
     @Test
     public void testGzipBase64Empty() throws Exception {
-        String nullResult = CompressionUtils.gzipBase64(null);
-        Assert.assertEquals(null, nullResult);
+        String nullBytesResult = CompressionUtils.gzipBase64UrlSafe((byte[]) null);
+        Assert.assertEquals(null, nullBytesResult);
 
-        String emptyResult = CompressionUtils.gzipBase64("");
+        String nullStringResult = CompressionUtils.gzipBase64UrlSafe((String) null);
+        Assert.assertEquals(null, nullStringResult);
+
+        String emptyResult = CompressionUtils.gzipBase64UrlSafe("");
         Assert.assertEquals("", emptyResult);
     }
 
@@ -88,17 +91,15 @@ public class CompressionUtilsTest {
                 + "  }\n"
                 + "]";
 
-        String compressed = CompressionUtils.gzipBase64(json);
+        String compressed = CompressionUtils.gzipBase64UrlSafe(json);
 
-        String expected = "H4sIAAAAAAAAALXVzY7TMBAH8Ps-RZXzbmKPPZ5Jr7wBV4TQ-ItWtNvQpBfQvjuGVkJa7aoGxYfk\n"
-                + "ENvzT_yLxp8eNpuf5dpsumc5pm7bTXJOz8sT9Nir7vE69GM_eTkcvlzOhzJjtyzTvB0Gmfb91_2y\n"
-                + "u_g-nI7DOU2neZi_X0qB4fTt96zhtnB4q-gi5_8relv4ZtGy5rhfuu31m8qDeSelejbOp2i1MMHo\n"
-                + "IoforPYYlFOQg2enciJlza1MWffPb3VNnofqqD9JL-X-8vg-gu3V08cPen2IV4XXw3hV-B0QDIGi\n"
-                + "FyNR40gZg5SbYSWWLUZlGLPYMrACSHVULUgTjCYQdxDKD8o-JUATM8no2WcTsrWGRRSRAKOCoPQK\n"
-                + "CNVRVQimBYJpgWDuIgQ7phRT-UHJJuV8YMgoKVJwhMplhzGCZVgBoTqqCgFaIEALBLiL4CSVnfAm\n"
-                + "lB0YS7_G0sM5GQFUOmeyKkbRqN0KCNVRVQi61fmgW50Puup8IO-ItPcwmjEKJIoWghgchUIOSlxi\n"
-                + "BwR-jdZUG1UL0gSjCcQdBHbRknYeWaJxCAkTOfYBIbMi1qWRl9ahwwoI1VF_ER4-_wL2RqAwvQoA\n"
-                + "AA==\n";
+        String expected = "H4sIAAAAAAAAALXVzY7TMBAH8Ps-RZXzbmKPPZ5Jr7wBV4TQ-ItWtNvQpBfQvjuGVkJa7aoGxYfkENvzT_yLxp8eNpuf"
+                + "5dpsumc5pm7bTXJOz8sT9Nir7vE69GM_eTkcvlzOhzJjtyzTvB0Gmfb91_2yu_g-nI7DOU2neZi_X0qB4fTt96zhtnB4q-gi5_8r"
+                + "elv4ZtGy5rhfuu31m8qDeSelejbOp2i1MMHoIoforPYYlFOQg2enciJlza1MWffPb3VNnofqqD9JL-X-8vg-gu3V08cPen2IV4XX"
+                + "w3hV-B0QDIGiFyNR40gZg5SbYSWWLUZlGLPYMrACSHVULUgTjCYQdxDKD8o-JUATM8no2WcTsrWGRRSRAKOCoPQKCNVRVQimBYJp"
+                + "gWDuIgQ7phRT-UHJJuV8YMgoKVJwhMplhzGCZVgBoTqqCgFaIEALBLiL4CSVnfAmlB0YS7_G0sM5GQFUOmeyKkbRqN0KCNVRVQi6"
+                + "1fmgW50Puup8IO-ItPcwmjEKJIoWghgchUIOSlxiBwR-jdZUG1UL0gSjCcQdBHbRknYeWaJxCAkTOfYBIbMi1qWRl9ahwwoI1VF_"
+                + "ER4-_wL2RqAwvQoAAA==";
 
         Assert.assertEquals(expected, compressed);
     }

--- a/core/src/main/java/com/github/simonpercic/oklog/core/CompressionUtils.java
+++ b/core/src/main/java/com/github/simonpercic/oklog/core/CompressionUtils.java
@@ -1,10 +1,12 @@
 package com.github.simonpercic.oklog.core;
 
-import android.util.Base64;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.zip.GZIPOutputStream;
+
+import okio.BufferedSink;
+import okio.ByteString;
+import okio.GzipSink;
+import okio.Okio;
 
 /**
  * Compression utilities.
@@ -44,17 +46,19 @@ final class CompressionUtils {
             return null;
         }
 
-        ByteArrayOutputStream byteOut = new ByteArrayOutputStream(bytes.length);
+        ByteArrayOutputStream out = new ByteArrayOutputStream(bytes.length);
+        BufferedSink gzipSink = Okio.buffer(new GzipSink(Okio.sink(out)));
+        gzipSink.write(bytes);
 
-        GZIPOutputStream gzip = new GZIPOutputStream(byteOut);
-        gzip.write(bytes);
-        gzip.close();
+        gzipSink.close();
 
-        byte[] result = byteOut.toByteArray();
+        byte[] result = out.toByteArray();
 
-        byteOut.close();
+        out.close();
 
-        return Base64.encodeToString(result, Base64.URL_SAFE);
+        ByteString byteString = ByteString.of(result);
+
+        return byteString.base64Url();
     }
 
     /**

--- a/core/src/main/java/com/github/simonpercic/oklog/core/CompressionUtils.java
+++ b/core/src/main/java/com/github/simonpercic/oklog/core/CompressionUtils.java
@@ -24,7 +24,7 @@ final class CompressionUtils {
      * @return gzipped and Base64 encoded input string
      * @throws IOException IO Exception
      */
-    static String gzipBase64(String string) throws IOException {
+    private static String gzipBase64(String string) throws IOException {
         if (StringUtils.isEmpty(string)) {
             return string;
         }

--- a/core/src/test/java/com/github/simonpercic/oklog/core/CompressionUtilsUnitTest.java
+++ b/core/src/test/java/com/github/simonpercic/oklog/core/CompressionUtilsUnitTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
  *
  * @author Simon Percic <a href="https://github.com/simonpercic">https://github.com/simonpercic</a>
  */
-public class CompressionUtilsTest {
+public class CompressionUtilsUnitTest {
 
     @Test
     public void testGzipBase64Empty() throws Exception {

--- a/core/src/test/java/com/github/simonpercic/oklog/core/LogManagerUnitTest.java
+++ b/core/src/test/java/com/github/simonpercic/oklog/core/LogManagerUnitTest.java
@@ -47,7 +47,7 @@ public class LogManagerUnitTest {
 
     @Test
     public void testGetLogUrlIOException() throws Exception {
-        when(CompressionUtils.gzipBase64(anyString())).thenThrow(new IOException());
+        when(CompressionUtils.gzipBase64UrlSafe(anyString())).thenThrow(new IOException());
 
         String baseUrl = "http://example.com";
         LogManager logManager = new LogManager(baseUrl, null, false, false, false, LOG_DATA_CONFIG_NONE);
@@ -60,7 +60,7 @@ public class LogManagerUnitTest {
 
     @Test
     public void testGetLogUrlEmpty() throws Exception {
-        when(CompressionUtils.gzipBase64(anyString())).thenReturn("");
+        when(CompressionUtils.gzipBase64UrlSafe(anyString())).thenReturn("");
 
         String baseUrl = "http://example.com";
         LogManager logManager = new LogManager(baseUrl, null, false, false, false, LOG_DATA_CONFIG_ALL);


### PR DESCRIPTION
- Using Okio for Base64 encoding and gzip compression instead of Android Base64
- Moved CompressionUtilsTest to unit test, removed test runner dependency in oklog-core